### PR TITLE
Add more accurate PSX shading precision calculation

### DIFF
--- a/shaders/psx_lit.shader
+++ b/shaders/psx_lit.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
+render_mode
+	diffuse_lambert_wrap, vertex_lighting, cull_disabled,
+	shadows_disabled, ambient_light_disabled, depth_draw_opaque;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,16 +10,19 @@ uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
-uniform int color_depth = 15;
+uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
-uniform vec2 uv_pan_velocity = vec2(0.0);
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -29,29 +34,11 @@ float inv_lerp(float from, float to, float value)
 	return (value - from) / (to - from);
 }
 
-// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
+// https://stackoverflow.com/a/42470600
+vec3 band_color(vec3 _color, int num_of_colors)
 {
-	UV = UV * uv_scale + uv_offset;
-	UV += uv_pan_velocity * TIME;
-
-	// Vertex snapping
-	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
+	vec3 num_of_colors_vec = vec3(float(num_of_colors));
+	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
 float get_dither_brightness(vec3 albedo, vec4 fragcoord)
@@ -87,15 +74,42 @@ float get_dither_brightness(vec3 albedo, vec4 fragcoord)
 	}
 }
 
-// https://stackoverflow.com/a/42470600
-vec3 band_color(vec3 _color, int num_of_colors)
+// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
 {
-	vec3 num_of_colors_vec = vec3(float(num_of_colors));
-	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
+	UV = UV * uv_scale + uv_offset;
+	UV += uv_pan_velocity * TIME;
+
+	// Vertex snapping
+	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	ALBEDO = COLOR.rgb;
 	ALBEDO *= (texture(albedoTex, UV) * modulate_color).rgb;
 	ALBEDO = fog_enabled ? mix(ALBEDO, fog_color.rgb, fog_weight) : ALBEDO;

--- a/shaders/psx_lit.shader
+++ b/shaders/psx_lit.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -17,13 +19,17 @@ uniform vec2 uv_pan_velocity = vec2(0.0);
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
@@ -31,12 +37,11 @@ void vertex()
 
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_lit.shader
+++ b/shaders/psx_lit.shader
@@ -18,7 +18,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_lit.shader
+++ b/shaders/psx_lit.shader
@@ -12,7 +12,7 @@ uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
 uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -100,7 +100,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_lit_alpha-scissor.shader
+++ b/shaders/psx_lit_alpha-scissor.shader
@@ -21,7 +21,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_lit_alpha-scissor.shader
+++ b/shaders/psx_lit_alpha-scissor.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
+render_mode
+	diffuse_lambert_wrap, vertex_lighting, cull_disabled,
+	shadows_disabled, ambient_light_disabled, depth_draw_alpha_prepass;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,19 +10,22 @@ uniform vec4 modulate_color : hint_color = vec4(1.);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
+uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool billboard = false;
 uniform bool y_billboard = false;
-uniform int color_depth = 15;
 uniform float alpha_scissor : hint_range(0, 1) = 0.1;
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
-uniform vec2 uv_pan_velocity = vec2(0.0);
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -37,46 +42,6 @@ vec4 band_color(vec4 _color, int num_of_colors)
 {
 	vec4 num_of_colors_vec = vec4(float(num_of_colors));
 	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
-}
-
-// https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
-{
-	UV = UV * uv_scale + uv_offset;
-
-	if (y_billboard)
-	{
-		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],WORLD_MATRIX[1],vec4(normalize(cross(CAMERA_MATRIX[0].xyz,WORLD_MATRIX[1].xyz)), 0.0),WORLD_MATRIX[3]);
-		MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(1.0, 0.0, 0.0, 0.0),vec4(0.0, 1.0/length(WORLD_MATRIX[1].xyz), 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0),vec4(0.0, 0.0, 0.0 ,1.0));
-	}
-	else if (billboard)
-	{
-		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);
-	}
-
-	// Vertex snapping
-	// Based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	if (y_billboard)
-	{
-		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);
-		MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(WORLD_MATRIX[0].xyz), 0.0, 0.0, 0.0),vec4(0.0, length(WORLD_MATRIX[1].xyz), 0.0, 0.0),vec4(0.0, 0.0, length(WORLD_MATRIX[2].xyz), 0.0),vec4(0.0, 0.0, 0.0, 1.0));
-	}
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
 }
 
 float get_dither_brightness(vec4 tex, vec4 fragcoord)
@@ -112,8 +77,57 @@ float get_dither_brightness(vec4 tex, vec4 fragcoord)
 	}
 }
 
+// https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
+{
+	UV = UV * uv_scale + uv_offset;
+
+	if (y_billboard)
+	{
+		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],WORLD_MATRIX[1],vec4(normalize(cross(CAMERA_MATRIX[0].xyz,WORLD_MATRIX[1].xyz)), 0.0),WORLD_MATRIX[3]);
+		MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(1.0, 0.0, 0.0, 0.0),vec4(0.0, 1.0/length(WORLD_MATRIX[1].xyz), 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0),vec4(0.0, 0.0, 0.0 ,1.0));
+	}
+	else if (billboard)
+	{
+		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);
+	}
+
+	// Vertex snapping
+	// Based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	if (y_billboard)
+	{
+		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);
+		MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(WORLD_MATRIX[0].xyz), 0.0, 0.0, 0.0),vec4(0.0, length(WORLD_MATRIX[1].xyz), 0.0, 0.0),vec4(0.0, 0.0, length(WORLD_MATRIX[2].xyz), 0.0),vec4(0.0, 0.0, 0.0, 1.0));
+	}
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
+}
+
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	vec4 tex = texture(albedoTex, UV) * modulate_color;
 	tex = fog_enabled ? mix(tex, fog_color, fog_weight) : tex;
 	tex = dither_enabled ? tex * get_dither_brightness(tex, FRAGCOORD) : tex;

--- a/shaders/psx_lit_alpha-scissor.shader
+++ b/shaders/psx_lit_alpha-scissor.shader
@@ -15,7 +15,7 @@ uniform bool billboard = false;
 uniform bool y_billboard = false;
 uniform float alpha_scissor : hint_range(0, 1) = 0.1;
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -118,7 +118,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_lit_alpha-scissor.shader
+++ b/shaders/psx_lit_alpha-scissor.shader
@@ -1,9 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
 
-const float psx_fixed_point_precision = 16.16;
-
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -21,6 +21,11 @@ uniform vec2 uv_pan_velocity = vec2(0.0);
 
 varying float fog_weight;
 varying float vertex_distance;
+
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
 
 float inv_lerp(float from, float to, float value)
 {
@@ -51,12 +56,11 @@ void vertex()
 
 	// Vertex snapping
 	// Based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_lit_metal.shader
+++ b/shaders/psx_lit_metal.shader
@@ -17,7 +17,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying vec3 cubemap_UV;
 varying float fog_weight;

--- a/shaders/psx_lit_metal.shader
+++ b/shaders/psx_lit_metal.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
@@ -17,23 +19,26 @@ varying vec3 cubemap_UV;
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_lit_metal.shader
+++ b/shaders/psx_lit_metal.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
+render_mode
+	diffuse_lambert_wrap, vertex_lighting, cull_disabled,
+	shadows_disabled, ambient_light_disabled, depth_draw_opaque;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,16 +10,19 @@ uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
 uniform vec3 cubemap_uv_scale = vec3(1.0);
-uniform int color_depth = 15;
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying vec3 cubemap_UV;
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -29,42 +34,11 @@ float inv_lerp(float from, float to, float value)
 	return (value - from) / (to - from);
 }
 
-// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
+// https://stackoverflow.com/a/42470600
+vec3 band_color(vec3 _color, int num_of_colors)
 {
-	// Vertex snapping
-	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
-
-	// define cubemap UV
-	// https://godotforums.org/discussion/15406/cubemap-reflections-cubic-environment-mapping
-	vec4 invcamx = INV_CAMERA_MATRIX[0];
-	vec4 invcamy = INV_CAMERA_MATRIX[1];
-	vec4 invcamz = INV_CAMERA_MATRIX[2];
-	vec4 invcamw = INV_CAMERA_MATRIX[3];
-
-	vec3 CameraPosition = -invcamw.xyz * mat3( invcamx.xyz, invcamy.xyz, invcamz.xyz );
-
-	vec3 vertexW = (WORLD_MATRIX * vec4(VERTEX, 0.0)).xyz; 		//vertex from model to world space
-	vec3 N = normalize(WORLD_MATRIX * vec4(NORMAL.x, NORMAL.y, NORMAL.z, 0.0)).xyz;	//normal from model space to world space
-	vec3 I = normalize(vertexW - CameraPosition);				//incident vector (from camera to vertex)
-	vec3 R = reflect(I, N);					//reflection vector (from vertex to cube map)
-	R.z *= -1.0;
-	cubemap_UV = R;
+	vec3 num_of_colors_vec = vec3(float(num_of_colors));
+	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
 float get_dither_brightness(vec3 albedo, vec4 fragcoord)
@@ -100,15 +74,55 @@ float get_dither_brightness(vec3 albedo, vec4 fragcoord)
 	}
 }
 
-// https://stackoverflow.com/a/42470600
-vec3 band_color(vec3 _color, int num_of_colors)
+// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
 {
-	vec3 num_of_colors_vec = vec3(float(num_of_colors));
-	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
+	// Vertex snapping
+	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
+
+	// define cubemap UV
+	// https://godotforums.org/discussion/15406/cubemap-reflections-cubic-environment-mapping
+	vec4 invcamx = INV_CAMERA_MATRIX[0];
+	vec4 invcamy = INV_CAMERA_MATRIX[1];
+	vec4 invcamz = INV_CAMERA_MATRIX[2];
+	vec4 invcamw = INV_CAMERA_MATRIX[3];
+
+	vec3 CameraPosition = -invcamw.xyz * mat3( invcamx.xyz, invcamy.xyz, invcamz.xyz );
+
+	vec3 vertexW = (WORLD_MATRIX * vec4(VERTEX, 0.0)).xyz;  //vertex from model to world space
+	vec3 N = normalize(WORLD_MATRIX * vec4(NORMAL.x, NORMAL.y, NORMAL.z, 0.0)).xyz;  //normal from model space to world space
+	vec3 I = normalize(vertexW - CameraPosition);  //incident vector (from camera to vertex)
+	vec3 R = reflect(I, N);  //reflection vector (from vertex to cube map)
+	R.z *= -1.0;
+	cubemap_UV = R;
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	ALBEDO = (COLOR * modulate_color).rgb;
 	vec4 cube_tex = texture(cubemap, cubemap_UV * cubemap_uv_scale) * metal_modulate_color;
 	ALBEDO *= cube_tex.rgb;

--- a/shaders/psx_lit_metal.shader
+++ b/shaders/psx_lit_metal.shader
@@ -11,7 +11,7 @@ uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
 uniform vec3 cubemap_uv_scale = vec3(1.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -97,7 +97,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_lit_transparent.shader
+++ b/shaders/psx_lit_transparent.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, vertex_lighting, cull_disabled, shadows_disabled, ambient_light_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -17,13 +19,17 @@ uniform vec2 uv_pan_velocity = vec2(0.0);
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
@@ -31,12 +37,11 @@ void vertex()
 
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_lit_transparent.shader
+++ b/shaders/psx_lit_transparent.shader
@@ -18,7 +18,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_lit_transparent.shader
+++ b/shaders/psx_lit_transparent.shader
@@ -12,7 +12,7 @@ uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
 uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -100,7 +100,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_unlit.shader
+++ b/shaders/psx_unlit.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
+render_mode
+	diffuse_lambert_wrap, unshaded, cull_disabled,
+	depth_draw_opaque;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,16 +10,19 @@ uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
-uniform int color_depth = 15;
+uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
-uniform vec2 uv_pan_velocity = vec2(0.0);
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -29,29 +34,11 @@ float inv_lerp(float from, float to, float value)
 	return (value - from) / (to - from);
 }
 
-// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
+// https://stackoverflow.com/a/42470600
+vec3 band_color(vec3 _color, int num_of_colors)
 {
-	UV = UV * uv_scale + uv_offset;
-	UV += uv_pan_velocity * TIME;
-
-	// Vertex snapping
-	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
+	vec3 num_of_colors_vec = vec3(float(num_of_colors));
+	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
 float get_dither_brightness(vec3 albedo, vec4 fragcoord)
@@ -87,15 +74,42 @@ float get_dither_brightness(vec3 albedo, vec4 fragcoord)
 	}
 }
 
-// https://stackoverflow.com/a/42470600
-vec3 band_color(vec3 _color, int num_of_colors)
+// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
 {
-	vec3 num_of_colors_vec = vec3(float(num_of_colors));
-	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
+	UV = UV * uv_scale + uv_offset;
+	UV += uv_pan_velocity * TIME;
+
+	// Vertex snapping
+	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	ALBEDO = COLOR.rgb;
 	ALBEDO *= (texture(albedoTex, UV) * modulate_color).rgb;
 	ALBEDO = fog_enabled ? mix(ALBEDO, fog_color.rgb, fog_weight) : ALBEDO;

--- a/shaders/psx_unlit.shader
+++ b/shaders/psx_unlit.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -17,13 +19,17 @@ uniform vec2 uv_pan_velocity = vec2(0.0);
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
@@ -31,12 +37,11 @@ void vertex()
 
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_unlit.shader
+++ b/shaders/psx_unlit.shader
@@ -18,7 +18,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_unlit.shader
+++ b/shaders/psx_unlit.shader
@@ -12,7 +12,7 @@ uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
 uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -100,7 +100,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_unlit_alpha-scissor.shader
+++ b/shaders/psx_unlit_alpha-scissor.shader
@@ -14,7 +14,7 @@ uniform bool billboard = false;
 uniform bool y_billboard = false;
 uniform float alpha_scissor : hint_range(0, 1) = 0.1;
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -118,7 +118,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_unlit_alpha-scissor.shader
+++ b/shaders/psx_unlit_alpha-scissor.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -11,6 +13,11 @@ uniform bool y_billboard = false;
 uniform int color_depth = 15;
 uniform float alpha_scissor : hint_range(0, 1) = 0.1;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 // https://stackoverflow.com/a/42470600
 vec4 band_color(vec4 _color, int num_of_colors)
 {
@@ -19,7 +26,6 @@ vec4 band_color(vec4 _color, int num_of_colors)
 }
 
 // https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
@@ -36,12 +42,11 @@ void vertex()
 
 	// Vertex snapping
 	// Based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_unlit_alpha-scissor.shader
+++ b/shaders/psx_unlit_alpha-scissor.shader
@@ -20,7 +20,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_unlit_alpha-scissor.shader
+++ b/shaders/psx_unlit_alpha-scissor.shader
@@ -1,5 +1,6 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded;
+render_mode
+	diffuse_lambert_wrap, unshaded, depth_draw_alpha_prepass;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,14 +9,31 @@ uniform vec4 modulate_color : hint_color = vec4(1.);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
+uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool billboard = false;
 uniform bool y_billboard = false;
-uniform int color_depth = 15;
 uniform float alpha_scissor : hint_range(0, 1) = 0.1;
+uniform bool dither_enabled = true;
+uniform int color_depth = 15;
+uniform bool fog_enabled = true;
+uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
+uniform float min_fog_distance : hint_range(0, 100) = 10;
+uniform float max_fog_distance : hint_range(0, 100) = 40;
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
+
+varying float fog_weight;
+varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
 	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
+float inv_lerp(float from, float to, float value)
+{
+	return (value - from) / (to - from);
 }
 
 // https://stackoverflow.com/a/42470600
@@ -25,10 +43,44 @@ vec4 band_color(vec4 _color, int num_of_colors)
 	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
+float get_dither_brightness(vec4 tex, vec4 fragcoord)
+{
+	const float pos_mult = 1.0;
+	vec4 position_new = fragcoord * pos_mult;
+	int x = int(position_new.x) % 4;
+	int y = int(position_new.y) % 4;
+	const float luminance_r = 0.2126;
+	const float luminance_g = 0.7152;
+	const float luminance_b = 0.0722;
+	float brightness = (luminance_r * tex.r) + (luminance_g * tex.g) + (luminance_b * tex.b);
+
+	// as of 3.2.2, matrix indices can only be accessed with constants, leading to this fun
+	float thresholdMatrix[16] = float[16] (
+		1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+		13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+		4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+		16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+	);
+
+	float dithering = thresholdMatrix[x * 4 + y];
+	const float brightness_mod = 0.2;
+	const float dither_cull_distance = 60.;
+	if ((brightness - brightness_mod < dithering) && (vertex_distance < dither_cull_distance))
+	{
+		const float dithering_effect_size = 0.25;
+		return ((dithering - 0.5) * dithering_effect_size) + 1.0;
+	}
+	else
+	{
+		return 1.;
+	}
+}
+
 // https://github.com/marmitoTH/godot-psx-shaders/
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
+	UV += uv_pan_velocity * TIME;
 
 	if (y_billboard)
 	{
@@ -51,16 +103,34 @@ void vertex()
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);
 
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
 	if (y_billboard)
 	{
 		MODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);
 		MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(WORLD_MATRIX[0].xyz), 0.0, 0.0, 0.0),vec4(0.0, length(WORLD_MATRIX[1].xyz), 0.0, 0.0),vec4(0.0, 0.0, length(WORLD_MATRIX[2].xyz), 0.0),vec4(0.0, 0.0, 0.0, 1.0));
 	}
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	vec4 tex = texture(albedoTex, UV) * modulate_color;
+	tex = fog_enabled ? mix(tex, fog_color, fog_weight) : tex;
+	tex = dither_enabled ? tex * get_dither_brightness(tex, FRAGCOORD) : tex;
 	tex = band_color(tex, color_depth);
 	ALBEDO = tex.rgb;
 	ALPHA = tex.a;

--- a/shaders/psx_unlit_metal.shader
+++ b/shaders/psx_unlit_metal.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
@@ -17,23 +19,26 @@ varying vec3 cubemap_UV;
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_unlit_metal.shader
+++ b/shaders/psx_unlit_metal.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
+render_mode
+	diffuse_lambert_wrap, unshaded, cull_disabled,
+	depth_draw_opaque;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,16 +10,19 @@ uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
 uniform vec3 cubemap_uv_scale = vec3(1.0);
-uniform int color_depth = 15;
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying vec3 cubemap_UV;
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -29,42 +34,11 @@ float inv_lerp(float from, float to, float value)
 	return (value - from) / (to - from);
 }
 
-// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
+// https://stackoverflow.com/a/42470600
+vec3 band_color(vec3 _color, int num_of_colors)
 {
-	// Vertex snapping
-	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
-
-	// define cubemap UV
-	// https://godotforums.org/discussion/15406/cubemap-reflections-cubic-environment-mapping
-	vec4 invcamx = INV_CAMERA_MATRIX[0];
-	vec4 invcamy = INV_CAMERA_MATRIX[1];
-	vec4 invcamz = INV_CAMERA_MATRIX[2];
-	vec4 invcamw = INV_CAMERA_MATRIX[3];
-
-	vec3 CameraPosition = -invcamw.xyz * mat3( invcamx.xyz, invcamy.xyz, invcamz.xyz );
-
-	vec3 vertexW = (WORLD_MATRIX * vec4(VERTEX, 0.0)).xyz; 		//vertex from model to world space
-	vec3 N = normalize(WORLD_MATRIX * vec4(NORMAL.x, NORMAL.y, NORMAL.z, 0.0)).xyz;	//normal from model space to world space
-	vec3 I = normalize(vertexW - CameraPosition);				//incident vector (from camera to vertex)
-	vec3 R = reflect(I, N);					//reflection vector (from vertex to cube map)
-	R.z *= -1.0;
-	cubemap_UV = R;
+	vec3 num_of_colors_vec = vec3(float(num_of_colors));
+	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
 float get_dither_brightness(vec3 albedo, vec4 fragcoord)
@@ -100,15 +74,55 @@ float get_dither_brightness(vec3 albedo, vec4 fragcoord)
 	}
 }
 
-// https://stackoverflow.com/a/42470600
-vec3 band_color(vec3 _color, int num_of_colors)
+// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
 {
-	vec3 num_of_colors_vec = vec3(float(num_of_colors));
-	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
+	// Vertex snapping
+	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
+
+	// define cubemap UV
+	// https://godotforums.org/discussion/15406/cubemap-reflections-cubic-environment-mapping
+	vec4 invcamx = INV_CAMERA_MATRIX[0];
+	vec4 invcamy = INV_CAMERA_MATRIX[1];
+	vec4 invcamz = INV_CAMERA_MATRIX[2];
+	vec4 invcamw = INV_CAMERA_MATRIX[3];
+
+	vec3 CameraPosition = -invcamw.xyz * mat3( invcamx.xyz, invcamy.xyz, invcamz.xyz );
+
+	vec3 vertexW = (WORLD_MATRIX * vec4(VERTEX, 0.0)).xyz;  //vertex from model to world space
+	vec3 N = normalize(WORLD_MATRIX * vec4(NORMAL.x, NORMAL.y, NORMAL.z, 0.0)).xyz;  //normal from model space to world space
+	vec3 I = normalize(vertexW - CameraPosition);  //incident vector (from camera to vertex)
+	vec3 R = reflect(I, N);  // reflection vector (from vertex to cube map)
+	R.z *= -1.0;
+	cubemap_UV = R;
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	ALBEDO = (COLOR * modulate_color).rgb;
 	vec4 tex = texture(cubemap, cubemap_UV * cubemap_uv_scale) * metal_modulate_color;
 	ALBEDO *= tex.rgb;

--- a/shaders/psx_unlit_metal.shader
+++ b/shaders/psx_unlit_metal.shader
@@ -17,7 +17,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying vec3 cubemap_UV;
 varying float fog_weight;

--- a/shaders/psx_unlit_metal.shader
+++ b/shaders/psx_unlit_metal.shader
@@ -11,7 +11,7 @@ uniform vec4 metal_modulate_color : hint_color = vec4(1.0);
 uniform samplerCube cubemap;
 uniform vec3 cubemap_uv_scale = vec3(1.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -97,7 +97,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);

--- a/shaders/psx_unlit_transparent.shader
+++ b/shaders/psx_unlit_transparent.shader
@@ -1,7 +1,9 @@
 shader_type spatial;
 render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
 
-uniform float precision_multiplier = 2.;
+uniform vec2 precision_ratio = vec2(4.0, 3.0);
+uniform float precision_height = 240.0;
+uniform float precision_multiplier = 1.;
 uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
@@ -17,13 +19,17 @@ uniform vec2 uv_pan_velocity = vec2(0.0);
 varying float fog_weight;
 varying float vertex_distance;
 
+vec2 get_vertex_snap_step()
+{
+	return vec2(length(normalize(precision_ratio)) * precision_height, precision_height) * precision_multiplier;
+}
+
 float inv_lerp(float from, float to, float value)
 {
 	return (value - from) / (to - from);
 }
 
 // originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-const float psx_fixed_point_precision = 16.16;
 void vertex()
 {
 	UV = UV * uv_scale + uv_offset;
@@ -31,12 +37,11 @@ void vertex()
 
 	// Vertex snapping
 	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	float vertex_snap_step = psx_fixed_point_precision * precision_multiplier;
+	vec2 vertex_snap_step = get_vertex_snap_step();
 	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
 	vec4 clip_vertex = snap_to_pixel;
 	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.x = floor(vertex_snap_step * clip_vertex.x) / vertex_snap_step;
-	clip_vertex.y = floor(vertex_snap_step * clip_vertex.y) / vertex_snap_step;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
 	clip_vertex.xyz *= snap_to_pixel.w;
 	POSITION = clip_vertex;
 	POSITION /= abs(POSITION.w);

--- a/shaders/psx_unlit_transparent.shader
+++ b/shaders/psx_unlit_transparent.shader
@@ -18,7 +18,7 @@ uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
 uniform bool draw_distance_enabled = true;
-uniform float draw_distance : hint_range(0, 100) = 10.0;
+uniform float draw_distance : hint_range(0, 100) = 40.0;
 
 varying float fog_weight;
 varying float vertex_distance;

--- a/shaders/psx_unlit_transparent.shader
+++ b/shaders/psx_unlit_transparent.shader
@@ -1,5 +1,7 @@
 shader_type spatial;
-render_mode skip_vertex_transform, diffuse_lambert_wrap, unshaded, cull_disabled;
+render_mode
+	diffuse_lambert_wrap, unshaded, cull_disabled,
+	depth_draw_alpha_prepass;
 
 uniform vec2 precision_ratio = vec2(4.0, 3.0);
 uniform float precision_height = 240.0;
@@ -8,16 +10,19 @@ uniform vec4 modulate_color : hint_color = vec4(1.0);
 uniform sampler2D albedoTex : hint_albedo;
 uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
-uniform int color_depth = 15;
+uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
+uniform int color_depth = 15;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
 uniform float max_fog_distance : hint_range(0, 100) = 40;
-uniform vec2 uv_pan_velocity = vec2(0.0);
+uniform bool draw_distance_enabled = true;
+uniform float draw_distance : hint_range(0, 100) = 10.0;
 
 varying float fog_weight;
 varying float vertex_distance;
+varying float origin_distance;
 
 vec2 get_vertex_snap_step()
 {
@@ -29,29 +34,11 @@ float inv_lerp(float from, float to, float value)
 	return (value - from) / (to - from);
 }
 
-// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
-void vertex()
+// https://stackoverflow.com/a/42470600
+vec4 band_color(vec4 _color, int num_of_colors)
 {
-	UV = UV * uv_scale + uv_offset;
-	UV += uv_pan_velocity * TIME;
-
-	// Vertex snapping
-	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
-	vec2 vertex_snap_step = get_vertex_snap_step();
-	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
-	vec4 clip_vertex = snap_to_pixel;
-	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
-	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
-	clip_vertex.xyz *= snap_to_pixel.w;
-	POSITION = clip_vertex;
-	POSITION /= abs(POSITION.w);
-
-	VERTEX = VERTEX;  // it breaks without this
-	NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
-	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-
-	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
-	fog_weight = clamp(fog_weight, 0, 1);
+	vec4 num_of_colors_vec = vec4(float(num_of_colors));
+	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
 }
 
 float get_dither_brightness(vec3 albedo, vec4 fragcoord)
@@ -87,15 +74,42 @@ float get_dither_brightness(vec3 albedo, vec4 fragcoord)
 	}
 }
 
-// https://stackoverflow.com/a/42470600
-vec4 band_color(vec4 _color, int num_of_colors)
+// originally based on: https://github.com/marmitoTH/godot-psx-shaders/
+void vertex()
 {
-	vec4 num_of_colors_vec = vec4(float(num_of_colors));
-	return floor(_color * num_of_colors_vec) / num_of_colors_vec;
+	UV = UV * uv_scale + uv_offset;
+	UV += uv_pan_velocity * TIME;
+
+	// Vertex snapping
+	// based on https://github.com/BroMandarin/unity_lwrp_psx_shader/blob/master/PS1.shader
+	vec2 vertex_snap_step = get_vertex_snap_step();
+	vec4 snap_to_pixel = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	vec4 clip_vertex = snap_to_pixel;
+	clip_vertex.xyz = snap_to_pixel.xyz / snap_to_pixel.w;
+	clip_vertex.xy = floor(vertex_snap_step * clip_vertex.xy) / vertex_snap_step;
+	clip_vertex.xyz *= snap_to_pixel.w;
+	POSITION = clip_vertex;
+	POSITION /= abs(POSITION.w);
+
+	// Recalculate normal with new position
+	// Source: https://forum.unity.com/threads/shader-question-how-to-recalculate-normals-after-vertices-displacement.903248/
+	vec3 bitangent = cross(NORMAL, TANGENT.xyz);
+	vec3 nt = ((POSITION.xyz + TANGENT.xyz * 0.01) - POSITION.xyz );
+	vec3 nb = ((POSITION.xyz + bitangent * 0.01) - POSITION.xyz );
+	NORMAL = cross(nt, nb);
+
+	VERTEX = VERTEX;  // it breaks without this
+	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
+	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+
+	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
+	fog_weight = clamp(fog_weight, 0, 1);
 }
 
 void fragment()
 {
+	if (draw_distance_enabled && origin_distance > draw_distance) discard;
+
 	vec4 tex = texture(albedoTex, UV) * modulate_color;
 	ALBEDO = COLOR.rgb;
 	ALBEDO *= tex.rgb;

--- a/shaders/psx_unlit_transparent.shader
+++ b/shaders/psx_unlit_transparent.shader
@@ -12,7 +12,7 @@ uniform vec2 uv_scale = vec2(1.0, 1.0);
 uniform vec2 uv_offset = vec2(.0, .0);
 uniform vec2 uv_pan_velocity = vec2(0.0);
 uniform bool dither_enabled = true;
-uniform int color_depth = 15;
+uniform int color_depth = 32;
 uniform bool fog_enabled = true;
 uniform vec4 fog_color : hint_color = vec4(0.5, 0.7, 1.0, 1.0);
 uniform float min_fog_distance : hint_range(0, 100) = 10;
@@ -100,7 +100,7 @@ void vertex()
 
 	VERTEX = VERTEX;  // it breaks without this
 	vertex_distance = length((MODELVIEW_MATRIX * vec4(VERTEX, 1.0)));
-	origin_distance = length((MODELVIEW_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)));
+	origin_distance = length((CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz);
 
 	fog_weight = inv_lerp(min_fog_distance, max_fog_distance, vertex_distance);
 	fog_weight = clamp(fog_weight, 0, 1);


### PR DESCRIPTION
Hey, thanks for taking interest in the project!

Changes look good - only area I'm hesitant on is making `precision_ratio` and `precision_height` uniforms rather than constants. Is there any reason why a user would want to change these values?