### PR TITLE
precision multiplier on preprocessor changed to global uniform

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -58,3 +58,10 @@ quality/shading/force_blinn_over_ggx=true
 quality/filters/anisotropic_filter_level=1
 quality/subsurface_scattering/quality=0
 quality/subsurface_scattering/weight_samples=false
+
+[shader_globals]
+
+precision_multiplier={
+"type": "float",
+"value": 1.0
+}

--- a/shaders/psx_base.gdshaderinc
+++ b/shaders/psx_base.gdshaderinc
@@ -1,6 +1,6 @@
 render_mode LIT, cull_disabled, shadows_disabled, DEPTH, BLEND;
 
-uniform float precision_multiplier : hint_range(0.0, 1.0) = 1.0;
+global uniform float precision_multiplier : hint_range(0.0, 1.0) = 1.0;
 uniform vec4 modulate_color : source_color = vec4(1.0);
 
 #ifndef NO_TEXTURE


### PR DESCRIPTION
with the presicion multiplier converted to a global uniform using the new global uniform feature in 4.0 the player will be able to choose how many PSX fidelity would want in their projects. In case that this uniform wants to be adjusted per material, the user will just delete the global uniform and on the preprocessor change also the uniform (just deleting "global") float.