### PR TITLE
Add specular_disabled on render_mode

### DIFF
--- a/shaders/psx_base.gdshaderinc
+++ b/shaders/psx_base.gdshaderinc
@@ -1,4 +1,4 @@
-render_mode LIT, CULL, shadows_disabled, DEPTH, BLEND;
+render_mode LIT, CULL, shadows_disabled, DEPTH, BLEND, specular_disabled;
 
 global uniform float precision_multiplier : hint_range(0.0, 1.0) = 1.0;
 uniform vec4 modulate_color : source_color = vec4(1.0);


### PR DESCRIPTION
The PSX Shader Demo didn't include "specular_disabled" on "render_mode" like on the n64 shader demo.

In my opinion, it looks more authentic and fits more the PS1 aesthetic.

### Specular disabled
![image](https://github.com/MenacingMecha/godot-psx-style-demo/assets/57131645/55da294f-9423-4a40-a0d7-bce80202455b)

### Specular enabled
![image](https://github.com/MenacingMecha/godot-psx-style-demo/assets/57131645/2cb9d602-b183-4c68-a884-29b1daf4efb9)

What do you think?