### PR TITLE
Add warping multiplier

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ config/description="Demo project featuring a collection of PS1 style shaders and
 (MIT License)
 https://github.com/MenacingMecha/godot-psx-style-demo/"
 run/main_scene="res://post_process/pp_stack.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 run/max_fps=24
 config/icon="res://readme-assets/screenshot.png"
 
@@ -24,8 +24,8 @@ config/icon="res://readme-assets/screenshot.png"
 window/size/viewport_width=960
 window/size/viewport_height=720
 window/size/resizable=false
-window/vsync/vsync_mode=0
 window/stretch/mode="viewport"
+window/vsync/vsync_mode=0
 window/size/width=960
 window/size/height=720
 
@@ -62,6 +62,10 @@ quality/subsurface_scattering/weight_samples=false
 [shader_globals]
 
 precision_multiplier={
+"type": "float",
+"value": 1.0
+}
+warping_multiplier={
 "type": "float",
 "value": 1.0
 }

--- a/shaders/psx_base.gdshaderinc
+++ b/shaders/psx_base.gdshaderinc
@@ -1,6 +1,7 @@
 render_mode LIT, CULL, shadows_disabled, DEPTH, BLEND, specular_disabled;
 
 global uniform float precision_multiplier : hint_range(0.0, 1.0) = 1.0;
+global uniform float warping_multiplier : hint_range(0.0, 1.0) = 1.0;
 uniform vec4 modulate_color : source_color = vec4(1.0);
 
 #ifndef NO_TEXTURE
@@ -52,7 +53,7 @@ void vertex()
 #endif
 
 	POSITION = get_snapped_pos(PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0));  // snap position to grid
-	POSITION /= abs(POSITION.w);  // discard depth for affine mapping
+	POSITION = mix(POSITION, POSITION / abs(POSITION.w), warping_multiplier);  // discard depth for affine mapping
 
 #ifdef ALPHA_SCISSOR
 	if (y_billboard)


### PR DESCRIPTION
Hey, so I thought it should be possible, to also change the texture warping strength in the shader, like it's done with vertex jitter.
So I've added a "warping_multiplier" to shader globals and with the help of HPS1 I added the shader code to the base shader, so that texture warping can be changed.

What do you think, couldit be added?